### PR TITLE
Fix misspelling of canceled

### DIFF
--- a/foxx/types/build.js
+++ b/foxx/types/build.js
@@ -14,7 +14,7 @@ const BuildStatus = new gql.GraphQLEnumType({
     success: {},
     pending: {},
     running: {},
-    cancelded: {},
+    canceled: {},
     skipped: {}
   }
 });


### PR DESCRIPTION
`canceled` is misspelled in `foxx/types/build.js` which causes indexing failures if the value is `canceled`.